### PR TITLE
fix logo filename and path

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ title: ''
   </ul>
 
   <div class='logo-main'>
-      <img id='logo' src='{{site.baseurl}}/img/Hot-logo.png' alt='HOT Summit' />
+      <img id='logo' src='{{site.baseurl}}/img/Hot_logo.svg' alt='HOT Summit' />
   </div>
 
 </section>


### PR DESCRIPTION
@DylanMoriarty @xamanu The HOT logo wasn't showing because of a filename issue. This PR fixes it. 
